### PR TITLE
F2calv/2026 04 updates

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -4,8 +4,9 @@ branches:
     regex: ^main$
     label: ''
   feature:
-    regex: ^features?[/-]
-    label: useBranchName
+    mode: ContinuousDelivery
+    regex: ^(features?|f2calv|copilot)[/-](?<BranchName>.+)
+    label: '{BranchName}'
   preview:
     regex: ^preview?[/-]
     label: preview-{BranchName}

--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ steps:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
     configuration: Release
+
+# Push a pre-release package from a non-default branch, filtered to a specific package.
+- uses: f2calv/gha-dotnet-nuget@v2
+  with:
+    version: 1.2.3-my-feature.4
+    NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+    push-preview: true
+    package-filter: CasCap.Common.Caching
 ```
 
 Some working examples of this action in active use in my own public repositories, the following projects use this action via a shared [re-usable workflow](https://github.com/f2calv/gha-workflows/blob/main/.github/workflows/dotnet-publish-nuget.yml):
@@ -57,7 +65,7 @@ These projects use this action directly due to a non-standard testing process:
 | `configuration` | string | | `Release` | .NET build configuration e.g. `Debug` or `Release` |
 | `solution-name` | string | | | Specify exactly which .NET solution or project to build when multiple exist e.g. `MySolution.sln` or `MyProject.csproj` |
 | `push` | boolean | | `true` | Push packages to NuGet feeds |
-| `push-preview` | boolean | | `false` | Push a pre-release package from a non-default branch |
+| `push-preview` | boolean | | `false` | Push a pre-release NuGet package from a non-default branch. The version's SemVer pre-release suffix signals preview status to NuGet. |
 | `execute-tests` | boolean | | `true` | Execute unit tests |
 | `code-coverage` | boolean | | `true` | Execute code coverage tools |
 | `dotnet-restore-args` | string | | | Optional extra arguments for `dotnet restore` |
@@ -65,6 +73,24 @@ These projects use this action directly due to a non-standard testing process:
 | `dotnet-test-args` | string | | | Optional extra arguments for `dotnet test` |
 | `dotnet-pack-args` | string | | | Optional extra arguments for `dotnet pack` |
 | `dotnet-push-args` | string | | | Optional extra arguments for `dotnet nuget push` |
+| `package-filter` | string | | | Comma-separated list of package ID prefixes to push e.g. `CasCap.Common.Caching,CasCap.Common.Extensions`. When empty all packages are pushed. |
+
+## Push behaviour
+
+| Scenario | nuget.org | GitHub Packages |
+| --- | --- | --- |
+| Default branch, `push: true` | ✅ | ✅ |
+| Default branch, `push: false` | ❌ | ❌ |
+| Non-default branch, `push-preview: true` | ✅ | ❌ |
+| Non-default branch, `push-preview: false` | ❌ | ❌ |
+
+Preview packages are only pushed to nuget.org — GitHub Packages is reserved for stable releases from the default branch. NuGet automatically recognises a package as pre-release when the version contains a SemVer pre-release suffix (e.g. `1.2.3-my-feature.4`).
+
+### Package filtering
+
+When `package-filter` is set, only `.nupkg` files whose filename starts with one of the specified prefixes are pushed. This is useful during preview pushes to avoid cluttering nuget.org with packages that haven't actually changed.
+
+For example, if a solution produces `CasCap.Common.Caching`, `CasCap.Common.Extensions`, and `CasCap.Common.Serialization` packages, setting `package-filter: CasCap.Common.Caching` will push only the caching package.
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,7 @@ inputs:
     description: Should we push packages?
     default: true
   push-preview:
-    description: Publish NuGet package from a preview branch?
+    description: Push a pre-release NuGet package from a non-default branch? The version's SemVer pre-release suffix (e.g. 1.2.3-my-feature.4) signals preview status to NuGet.
     type: boolean
     default: false
   execute-tests:
@@ -60,6 +60,10 @@ inputs:
   dotnet-push-args:
     type: string
     description: Optional 'dotnet push' arguments.
+    default: ''
+  package-filter:
+    type: string
+    description: Comma-separated list of package ID prefixes to push e.g. 'CasCap.Common.Caching,CasCap.Common.Extensions'. When empty all packages are pushed.
     default: ''
 
 outputs:
@@ -142,29 +146,70 @@ runs:
         github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
           || inputs.push-preview == 'true'
 
+    - name: resolve .nupkg files to push
+      shell: bash
+      id: packages
+      if: |
+        github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+          || inputs.push-preview == 'true'
+      run: |
+        shopt -s globstar nullglob
+        all_packages=(${{ github.workspace }}/src/**/*.nupkg)
+        if [[ -n "${{ inputs.package-filter }}" ]]; then
+          IFS=',' read -ra FILTERS <<< "${{ inputs.package-filter }}"
+          matched=()
+          for pkg in "${all_packages[@]}"; do
+            name=$(basename "$pkg")
+            for filter in "${FILTERS[@]}"; do
+              filter=$(echo "$filter" | xargs)
+              if [[ "$name" == ${filter}.* ]]; then
+                matched+=("$pkg")
+                break
+              fi
+            done
+          done
+          packages=("${matched[@]}")
+        else
+          packages=("${all_packages[@]}")
+        fi
+        if [[ ${#packages[@]} -eq 0 ]]; then
+          echo "::warning::No .nupkg files matched the package filter '${{ inputs.package-filter }}'"
+        else
+          echo "Packages to push:"
+          printf '  %s\n' "${packages[@]}"
+        fi
+        printf '%s\n' "${packages[@]}" > "${{ runner.temp }}/nupkg-list.txt"
+        echo "count=${#packages[@]}" >> $GITHUB_OUTPUT
+
     - name: dotnet push (api.nuget.org)
       shell: bash
       run: |
-        if [[ -n "${{ inputs.NUGET_API_KEY }}" ]]; \
-        then
-          dotnet nuget push ${{ github.workspace }}/src/**/*.nupkg --skip-duplicate -k ${{ inputs.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json ${{ inputs.dotnet-push-args }}
+        if [[ -n "${{ inputs.NUGET_API_KEY }}" ]]; then
+          while IFS= read -r pkg; do
+            [[ -z "$pkg" ]] && continue
+            dotnet nuget push "$pkg" --skip-duplicate -k ${{ inputs.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json ${{ inputs.dotnet-push-args }}
+          done < "${{ runner.temp }}/nupkg-list.txt"
         else
           echo "::warning title=NUGET_API_KEY::NUGET_API_KEY is missing from secrets, skipping push to api.nuget.org"
         fi
       if: |
-        (inputs.push == 'true' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch))
-          || inputs.push-preview == 'true'
+        steps.packages.outputs.count > 0
+          && ((inputs.push == 'true' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch))
+            || inputs.push-preview == 'true')
 
     - name: dotnet push (nuget.pkg.github.com)
       shell: bash
       run: |
-        if [[ -n "${{ inputs.GITHUB_TOKEN }}" ]]; \
-        then
+        if [[ -n "${{ inputs.GITHUB_TOKEN }}" ]]; then
           #Note: GitHub Packages is not a full NuGet feed so for advanced NuGet functions the gpr tool (https://github.com/jcansdale/gpr) may be needed instead.
-          dotnet nuget push ${{ github.workspace }}/src/**/*.nupkg --skip-duplicate -k ${{ inputs.GITHUB_TOKEN }} -s https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json ${{ inputs.dotnet-push-args }}
+          while IFS= read -r pkg; do
+            [[ -z "$pkg" ]] && continue
+            dotnet nuget push "$pkg" --skip-duplicate -k ${{ inputs.GITHUB_TOKEN }} -s https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json ${{ inputs.dotnet-push-args }}
+          done < "${{ runner.temp }}/nupkg-list.txt"
         else
           echo "::warning title=GITHUB_TOKEN::GITHUB_TOKEN is missing from secrets, skipping push to nuget.pkg.github.com"
         fi
       if: |
-        (inputs.push == 'true' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch))
-          || inputs.push-preview == 'true'
+        steps.packages.outputs.count > 0
+          && inputs.push == 'true'
+          && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)


### PR DESCRIPTION
## Copilot Session Requests

- Add a `package-filter` input so that preview pushes can target specific packages instead of pushing everything to the public NuGet feed.
- Update `push-preview` description — the branch name is irrelevant; NuGet infers pre-release status from the SemVer suffix.
- Add the missing `execute-tests` input pass-through in the CasCap.Common CI workflow (out-of-repo, not in this diff).
- Only push preview packages to nuget.org, not to GitHub Packages.
- Update README.md with new input documentation, push behaviour table, and package filtering explanation.

## Commits

| Hash | Message | Author | Date |
| --- | --- | --- | --- |
| 1782769 | +semver:feature preview package-filter added | Alex Vincent | 2026-04-02 |
| 9de8e68 | fix versioning | Alex Vincent | 2026-04-01 |

## Files Changed

| File | Change | Insertions | Deletions |
| --- | --- | --- | --- |
| `GitVersion.yml` | Modified | 3 | 2 |
| `README.md` | Modified | 27 | 1 |
| `action.yml` | Modified | 56 | 11 |

_3 files changed, 86 insertions, 14 deletions._

## Change Details

### `action.yml` — new `package-filter` input and push logic overhaul

1. Added `package-filter` input (string, optional, defaults to empty) — accepts a comma-separated list of package ID prefixes.
2. Updated `push-preview` description to clarify that branch naming is irrelevant; the SemVer pre-release suffix is what signals preview status to NuGet.
3. Added a new **resolve .nupkg files to push** step after `dotnet pack`:
   - Collects all `.nupkg` files under `src/`.
   - When `package-filter` is set, filters to only packages whose filename starts with a listed prefix.
   - Writes the filtered list to a temp file and outputs a `count`.
   - Emits a warning annotation if no packages match the filter.
4. Rewrote both push steps (`api.nuget.org` and `nuget.pkg.github.com`) to read packages from the temp file and push individually, instead of using a glob pattern.
5. Added `steps.packages.outputs.count > 0` guard to both push steps so they skip entirely when no packages match.
6. Changed GitHub Packages push to **only run on the default branch** — the `push-preview` bypass was removed from this step, so preview packages are exclusive to nuget.org.

### `README.md` — documentation for new features

1. Added a preview push example to the Examples section showing `push-preview` + `package-filter` usage together.
2. Added `package-filter` row to the Inputs table.
3. Updated `push-preview` description in the Inputs table to match the action.
4. Added a **Push behaviour** section with a table showing which feeds receive packages in each scenario.
5. Added a **Package filtering** section explaining how the filter works with a concrete example.

### `GitVersion.yml` — branch configuration

1. Changed `feature` branch regex to also match `f2calv/` and `copilot/` prefixes (in addition to `features?/`).
2. Switched feature branch mode to `ContinuousDelivery`.
3. Changed label from `useBranchName` to `{BranchName}` for cleaner SemVer pre-release suffixes.