### PR TITLE
2026-04 maintenance: scoped instruction files, checkout@v7

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,10 @@
 # Copilot Instructions
 
+<!-- ── Synced section ─────────────────────────────────────────────────────
+     Everything above the "Project-Specific Overrides" heading is kept
+     identical across all f2calv repositories. Edit once, sync everywhere.
+     ──────────────────────────────────────────────────────────────────── -->
+
 ## GitHub Actions
 
 ### General
@@ -59,13 +64,59 @@
 ### README Consistency
 
 - Every project's `README.md` must stay in sync with its implementation. During any refactoring — and **always** before creating a new PR — scan the `README.md` for inconsistencies: outdated input/output names, missing or removed configuration options, or inaccurate examples. Update the README as part of the same change, not as a follow-up.
-- **Mermaid diagrams**: Use Mermaid diagrams in `README.md` files to illustrate GitHub Actions workflow chains. These diagrams make complex relationships immediately visible and must be kept in sync with the code they describe.
 - **Markdown tables**: Table separator rows must use spaces around pipes to match the spaced style used in header and data rows (e.g. `| --- | --- |` not `|---|---|`). This prevents MD060 (table-column-style) warnings.
+
+### Mermaid Diagrams
+
+Use Mermaid diagrams in `README.md` files to visualize complex relationships and flows. Choose the appropriate diagram type:
+
+#### Diagram Type Selection
+
+- **`flowchart`**: Sequential processes, data flow, event flow, service orchestration, CI/CD pipelines
+  - Direction: Use `TD` (top-down) for vertical flows; `LR` (left-right) for wide workflows
+  - Example: GitHub Actions workflow chains, composite action steps
+
+- **`graph`**: Relationships, dependencies, hierarchies (non-sequential)
+  - Direction: Use `TD` for dependency trees; `LR` for peer relationships
+  - Example: Action dependencies, workflow call chains
+
+#### Standard Headings
+
+Use these consistent heading patterns before Mermaid diagrams:
+
+| Heading | Use For |
+| --- | --- |
+| `## Deployment Flow` | CI/CD pipelines, GitHub Actions workflows, action call chains |
+| `## Dependency Graph` | Action dependencies, workflow relationships |
+
+#### Styling Guidelines
+
+- **Subgraphs**: Group related steps or jobs
+- **Custom styling**: Define `classDef` for highlighting owned vs. third-party actions
+- **Node shapes**:
+  - `[ ]` rectangle (default) - actions, jobs
+  - `([ ])` stadium - workflows
+  - `{ }` diamond - decision points
+
+#### Synchronization
+
+- Mermaid diagrams must stay in sync with action/workflow changes
+- When renaming inputs/outputs, update corresponding diagram nodes
+- When adding/removing action dependencies, update dependency graphs
+- Review all `README.md` diagrams before creating PRs
 
 ## Copilot Workflow
 
+- **Test execution**: Never run tests automatically — they may be integration tests requiring extra setup. Always prompt (ideally with a visual yes/no button) before running any tests.
 - **Preserve git history during renames/moves**: When renaming or relocating files, first perform the rename/move (preferably via `git mv`), then make content edits to the file in its new location/name. This two-step approach preserves git history across the rename. Do not delete-and-recreate files when a rename or move is the intent.
 
 ## Misc
 
 - When detecting new conventions or patterns in the codebase, add them to this document and apply them retroactively where applicable.
+- When multiple `copilot-instructions.md` files are available in the workspace, keep them in sync based on the common guidelines in the synced section.
+
+---
+
+## Project-Specific Overrides
+
+<!-- This section is excluded from cross-repository sync. Place any repo-specific rules below. -->

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -22,6 +22,7 @@ The conventions below always apply, regardless of the file being edited.
 
 - **Test execution**: Never run tests automatically — they may be integration tests requiring extra setup. Always prompt (ideally with a visual yes/no button) before running any tests.
 - **Preserve git history during renames/moves**: When renaming or relocating files, first perform the rename/move (preferably via `git mv`), then make content edits to the file in its new location/name. This two-step approach preserves git history across the rename. Do not delete-and-recreate files when a rename or move is the intent.
+- **Multi-repo commits**: When a single change spans multiple repositories, separate per-repository commit messages are acceptable (but not mandatory). Prefer them where the changes are disconnected, or where one repository should not really "know about" the other (e.g. an app repo and a GitOps repo). A single shared commit message is fine when the change is genuinely coupled.
 
 ## Repository Structure
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,109 +1,22 @@
 # Copilot Instructions
 
 <!-- ── Synced section ─────────────────────────────────────────────────────
-     Everything above the "Project-Specific Overrides" heading is kept
-     identical across all f2calv repositories. Edit once, sync everywhere.
+     This file plus every file under `.github/instructions/` is kept
+     identical across all f2calv GitHub Action repositories. The repo-specific
+     "Project-Specific Overrides" section below is excluded from sync.
+     Edit once, sync everywhere.
      ──────────────────────────────────────────────────────────────────── -->
 
-## GitHub Actions
+## Instruction Files
 
-### General
+Detailed conventions live in scoped instruction files under `.github/instructions/`, auto-applied by file type:
 
-- Always leave **one blank line between steps** within a job for readability.
-- Pin actions to the **major version tag version by default** (e.g. `actions/checkout@v6`, `softprops/action-gh-release@v2`). Do not use SHA pinning or include minor/patch versions.
-- Set `fetch-depth: 0` on `actions/checkout` whenever GitVersion is used so it can read the full commit history. For lint-only workflows where history is unnecessary, `fetch-depth: 1` is acceptable.
-- Use explicit `permissions` blocks on every job; default to the minimum required (e.g. `contents: read`). Set global workflow-level permissions to `permissions: {}` (deny all) and grant per-job.
+| File | Applies to | Covers |
+| --- | --- | --- |
+| `github-actions.instructions.md` | workflows / `action.yml` | GitHub Actions naming, YAML, security, GitVersion |
+| `documentation.instructions.md` | `**/*.md` | README consistency & Mermaid diagrams |
 
-### Step Naming
-
-- **One-liners**: When a step's `run` block is a single command, use that command (or a slightly abbreviated form) as the step `name` rather than a descriptive prose label (e.g. `name: npm install --global json5`, not `name: setup json5`).
-- **Multi-part setup**: When a setup requires multiple steps, name each step with a `(N of M)` suffix (e.g. `name: setup yq (1 of 3)`, `name: setup yq (2 of 3)`, `name: setup yq (3 of 3)`).
-- **Matrix-based names**: Include matrix variables in step names for identification (e.g. `name: test (${{ matrix.gv-source }}, ${{ matrix.gv-config }})`).
-
-### Naming Conventions
-
-- **Inputs/outputs**: kebab-case (e.g. `image-registry`, `tag-override`, `git-user-name`).
-- **Environment variables**: ALL_UPPERCASE with underscores (e.g. `IMAGE_REGISTRY`, `TAG_OVERRIDE`, `MANIFEST_PATHS`).
-- **Secrets**: ALL_UPPERCASE with underscores (e.g. `GITHUB_TOKEN`, `GH_PAT_GITOPS`, `NUGET_API_KEY`).
-
-### YAML Style
-
-- **2-space indentation** for all workflow and action YAML files.
-- Do not quote strings unless YAML requires it (e.g. values containing special characters, reserved words like `true`/`false`/`null`, or strings that could be misinterpreted as another type).
-- For `workflow_dispatch` string inputs that represent booleans, use quoted defaults (e.g. `default: 'true'`).
-- Use `|` (pipe) for multi-line `run` scripts. Use `>` for flowing multi-line description text.
-- One blank line between major YAML sections (`on:`, `env:`, `jobs:`). No blank lines within input/output lists.
-
-### Reusable Workflows
-
-- **File naming**: Prefix reusable workflow filenames with an underscore to distinguish them from top-level entry-point workflows (e.g. `_gitops-helm-update.yml`, `_deploy-maui-android.yml`).
-- **Same repo**: `uses: ./.github/workflows/_filename.yml`
-- **Cross-repo**: `uses: owner/repo/.github/workflows/filename.yml@v1`
-- Prefer `secrets: inherit` unless there is a specific reason to restrict secrets passed to the called workflow.
-
-### Composite Actions
-
-- Declare `shell: bash` explicitly on every `run` step — composite actions do not inherit a default shell.
-- Reference scripts relative to the action root using `${{ github.action_path }}/scripts/name.sh`.
-
-### Security
-
-- Deny all permissions at workflow level (`permissions: {}`), grant only what each job requires.
-- Skip bot-triggered runs conditionally: `if: github.actor != 'dependabot[bot]'`.
-- Pass tokens via `stdin` for registry logins (e.g. `echo "$TOKEN" | docker login --password-stdin`).
-- OCI registry, repository and tag values must be forced to lowercase (e.g. `${IMAGE_REGISTRY,,}`).
-
-### GitVersion
-
-- Always set `fetch-depth: 0` on checkout when GitVersion is in use.
-- Default config file is `GitVersion.yml` in the repository root.
-- Prefer `semVer` for tags and releases; use `fullSemVer` (via the `version` output) for build versioning and pre-release identifiers.
-
-## Documentation
-
-### README Consistency
-
-- Every project's `README.md` must stay in sync with its implementation. During any refactoring — and **always** before creating a new PR — scan the `README.md` for inconsistencies: outdated input/output names, missing or removed configuration options, or inaccurate examples. Update the README as part of the same change, not as a follow-up.
-- **Markdown tables**: Table separator rows must use spaces around pipes to match the spaced style used in header and data rows (e.g. `| --- | --- |` not `|---|---|`). This prevents MD060 (table-column-style) warnings.
-
-### Mermaid Diagrams
-
-Use Mermaid diagrams in `README.md` files to visualize complex relationships and flows. Choose the appropriate diagram type:
-
-#### Diagram Type Selection
-
-- **`flowchart`**: Sequential processes, data flow, event flow, service orchestration, CI/CD pipelines
-  - Direction: Use `TD` (top-down) for vertical flows; `LR` (left-right) for wide workflows
-  - Example: GitHub Actions workflow chains, composite action steps
-
-- **`graph`**: Relationships, dependencies, hierarchies (non-sequential)
-  - Direction: Use `TD` for dependency trees; `LR` for peer relationships
-  - Example: Action dependencies, workflow call chains
-
-#### Standard Headings
-
-Use these consistent heading patterns before Mermaid diagrams:
-
-| Heading | Use For |
-| --- | --- |
-| `## Deployment Flow` | CI/CD pipelines, GitHub Actions workflows, action call chains |
-| `## Dependency Graph` | Action dependencies, workflow relationships |
-
-#### Styling Guidelines
-
-- **Subgraphs**: Group related steps or jobs
-- **Custom styling**: Define `classDef` for highlighting owned vs. third-party actions
-- **Node shapes**:
-  - `[ ]` rectangle (default) - actions, jobs
-  - `([ ])` stadium - workflows
-  - `{ }` diamond - decision points
-
-#### Synchronization
-
-- Mermaid diagrams must stay in sync with action/workflow changes
-- When renaming inputs/outputs, update corresponding diagram nodes
-- When adding/removing action dependencies, update dependency graphs
-- Review all `README.md` diagrams before creating PRs
+The conventions below always apply, regardless of the file being edited.
 
 ## Copilot Workflow
 
@@ -112,8 +25,8 @@ Use these consistent heading patterns before Mermaid diagrams:
 
 ## Misc
 
-- When detecting new conventions or patterns in the codebase, add them to this document and apply them retroactively where applicable.
-- When multiple `copilot-instructions.md` files are available in the workspace, keep them in sync based on the common guidelines in the synced section.
+- When detecting new conventions or patterns in the codebase, add them to the appropriate `.github/instructions/*.instructions.md` file (or this file for cross-cutting workflow rules) and apply them retroactively where applicable.
+- Keep this file and the `.github/instructions/` files in sync across repositories based on the common synced guidelines.
 
 ---
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -23,6 +23,25 @@ The conventions below always apply, regardless of the file being edited.
 - **Test execution**: Never run tests automatically — they may be integration tests requiring extra setup. Always prompt (ideally with a visual yes/no button) before running any tests.
 - **Preserve git history during renames/moves**: When renaming or relocating files, first perform the rename/move (preferably via `git mv`), then make content edits to the file in its new location/name. This two-step approach preserves git history across the rename. Do not delete-and-recreate files when a rename or move is the intent.
 
+## Repository Structure
+
+Every f2calv repository follows a consistent layout, regardless of language:
+
+- **Root files**: `README.md`, `LICENSE`, `GitVersion.yml`, `.editorconfig`, `.gitattributes`, `.gitignore`, and `.pre-commit-config.yaml` live in the repository root.
+- **Source code** lives under `src/`. *(Exception: GitHub Action repositories keep `action.yml` at the root per the GitHub Actions convention.)*
+- **Tooling** lives in dot-prefixed folders — `.github/` (workflows, instructions), `.scripts/`, `.devcontainer/`, `.docker/`, `.config/`, `.vscode/`.
+- **Additional documentation** beyond the root `README.md` lives as Markdown under `docs/`.
+- **`.gitattributes`** standardises line endings across Windows/Linux. Use:
+
+  ```gitattributes
+  * text=auto eol=lf
+  *.{cmd,[cC][mM][dD]} text eol=crlf
+  *.{bat,[bB][aA][tT]} text eol=crlf
+  ```
+
+- **`.editorconfig`** is the single source of truth for indentation, line endings, and analyzer/formatting rules.
+- **`GitVersion.yml`** in the root drives semantic-versioning rules.
+
 ## Misc
 
 - When detecting new conventions or patterns in the codebase, add them to the appropriate `.github/instructions/*.instructions.md` file (or this file for cross-cutting workflow rules) and apply them retroactively where applicable.

--- a/.github/instructions/documentation.instructions.md
+++ b/.github/instructions/documentation.instructions.md
@@ -1,0 +1,50 @@
+---
+description: 'README consistency and Mermaid diagram conventions for Markdown documentation.'
+applyTo: '**/*.md'
+---
+
+# Documentation
+
+## README Consistency
+
+- Every project's `README.md` must stay in sync with its implementation. During any refactoring — and **always** before creating a new PR — scan the `README.md` for inconsistencies: outdated input/output names, missing or removed configuration options, or inaccurate examples. Update the README as part of the same change, not as a follow-up.
+- **Markdown tables**: Table separator rows must use spaces around pipes to match the spaced style used in header and data rows (e.g. `| --- | --- |` not `|---|---|`). This prevents MD060 (table-column-style) warnings.
+
+## Mermaid Diagrams
+
+Use Mermaid diagrams in `README.md` files to visualize complex relationships and flows. Choose the appropriate diagram type:
+
+### Diagram Type Selection
+
+- **`flowchart`**: Sequential processes, data flow, event flow, service orchestration, CI/CD pipelines
+  - Direction: Use `TD` (top-down) for vertical flows; `LR` (left-right) for wide workflows
+  - Example: GitHub Actions workflow chains, composite action steps
+
+- **`graph`**: Relationships, dependencies, hierarchies (non-sequential)
+  - Direction: Use `TD` for dependency trees; `LR` for peer relationships
+  - Example: Action dependencies, workflow call chains
+
+### Standard Headings
+
+Use these consistent heading patterns before Mermaid diagrams:
+
+| Heading | Use For |
+| --- | --- |
+| `## Deployment Flow` | CI/CD pipelines, GitHub Actions workflows, action call chains |
+| `## Dependency Graph` | Action dependencies, workflow relationships |
+
+### Styling Guidelines
+
+- **Subgraphs**: Group related steps or jobs
+- **Custom styling**: Define `classDef` for highlighting owned vs. third-party actions
+- **Node shapes**:
+  - `[ ]` rectangle (default) - actions, jobs
+  - `([ ])` stadium - workflows
+  - `{ }` diamond - decision points
+
+### Synchronization
+
+- Mermaid diagrams must stay in sync with action/workflow changes
+- When renaming inputs/outputs, update corresponding diagram nodes
+- When adding/removing action dependencies, update dependency graphs
+- Review all `README.md` diagrams before creating PRs

--- a/.github/instructions/github-actions.instructions.md
+++ b/.github/instructions/github-actions.instructions.md
@@ -1,0 +1,58 @@
+---
+description: 'GitHub Actions workflow and composite-action conventions — naming, YAML style, security and GitVersion.'
+applyTo: '.github/workflows/**,.github/actions/**,**/action.yml,**/action.yaml'
+---
+
+# GitHub Actions
+
+## General
+
+- Always leave **one blank line between steps** within a job for readability.
+- Pin actions to the **major version tag version by default** (e.g. `actions/checkout@v6`, `softprops/action-gh-release@v2`). Do not use SHA pinning or include minor/patch versions.
+- Set `fetch-depth: 0` on `actions/checkout` whenever GitVersion is used so it can read the full commit history. For lint-only workflows where history is unnecessary, `fetch-depth: 1` is acceptable.
+- Use explicit `permissions` blocks on every job; default to the minimum required (e.g. `contents: read`). Set global workflow-level permissions to `permissions: {}` (deny all) and grant per-job.
+
+## Step Naming
+
+- **One-liners**: When a step's `run` block is a single command, use that command (or a slightly abbreviated form) as the step `name` rather than a descriptive prose label (e.g. `name: npm install --global json5`, not `name: setup json5`).
+- **Multi-part setup**: When a setup requires multiple steps, name each step with a `(N of M)` suffix (e.g. `name: setup yq (1 of 3)`, `name: setup yq (2 of 3)`, `name: setup yq (3 of 3)`).
+- **Matrix-based names**: Include matrix variables in step names for identification (e.g. `name: test (${{ matrix.gv-source }}, ${{ matrix.gv-config }})`).
+
+## Naming Conventions
+
+- **Inputs/outputs**: kebab-case (e.g. `image-registry`, `tag-override`, `git-user-name`).
+- **Environment variables**: ALL_UPPERCASE with underscores (e.g. `IMAGE_REGISTRY`, `TAG_OVERRIDE`, `MANIFEST_PATHS`).
+- **Secrets**: ALL_UPPERCASE with underscores (e.g. `GITHUB_TOKEN`, `GH_PAT_GITOPS`, `NUGET_API_KEY`).
+
+## YAML Style
+
+- **2-space indentation** for all workflow and action YAML files.
+- Do not quote strings unless YAML requires it (e.g. values containing special characters, reserved words like `true`/`false`/`null`, or strings that could be misinterpreted as another type).
+- For `workflow_dispatch` string inputs that represent booleans, use quoted defaults (e.g. `default: 'true'`).
+- Use `|` (pipe) for multi-line `run` scripts. Use `>` for flowing multi-line description text.
+- One blank line between major YAML sections (`on:`, `env:`, `jobs:`). No blank lines within input/output lists.
+
+## Reusable Workflows
+
+- **File naming**: Prefix reusable workflow filenames with an underscore to distinguish them from top-level entry-point workflows (e.g. `_gitops-helm-update.yml`, `_deploy-maui-android.yml`).
+- **Same repo**: `uses: ./.github/workflows/_filename.yml`
+- **Cross-repo**: `uses: owner/repo/.github/workflows/filename.yml@v1`
+- Prefer `secrets: inherit` unless there is a specific reason to restrict secrets passed to the called workflow.
+
+## Composite Actions
+
+- Declare `shell: bash` explicitly on every `run` step — composite actions do not inherit a default shell.
+- Reference scripts relative to the action root using `${{ github.action_path }}/scripts/name.sh`.
+
+## Security
+
+- Deny all permissions at workflow level (`permissions: {}`), grant only what each job requires.
+- Skip bot-triggered runs conditionally: `if: github.actor != 'dependabot[bot]'`.
+- Pass tokens via `stdin` for registry logins (e.g. `echo "$TOKEN" | docker login --password-stdin`).
+- OCI registry, repository and tag values must be forced to lowercase (e.g. `${IMAGE_REGISTRY,,}`).
+
+## GitVersion
+
+- Always set `fetch-depth: 0` on checkout when GitVersion is in use.
+- Default config file is `GitVersion.yml` in the repository root.
+- Prefer `semVer` for tags and releases; use `fullSemVer` (via the `version` output) for build versioning and pre-release identifiers.

--- a/.github/instructions/github-actions.instructions.md
+++ b/.github/instructions/github-actions.instructions.md
@@ -32,9 +32,17 @@ applyTo: '.github/workflows/**,.github/actions/**,**/action.yml,**/action.yaml'
 - Use `|` (pipe) for multi-line `run` scripts. Use `>` for flowing multi-line description text.
 - One blank line between major YAML sections (`on:`, `env:`, `jobs:`). No blank lines within input/output lists.
 
+## Reusability
+
+- **Reusability is a key requirement.** Factor cross-cutting GitHub Actions logic (build, test, lint, versioning, container/Helm packaging, EF migration-drift checks, etc.) into reusable `workflow_call` workflows in the `f2calv/gha-workflows` repo wherever it makes sense, so every repository consumes one implementation. Keep logic inline or in a repo-local reusable workflow only when it is genuinely repo-specific and unlikely to be reused.
+- **`gha-workflows` is the ideal home** for shared workflows. Parameterize them with `inputs` (paths, project/context names, configuration, flags) so they stay repo-agnostic; a consumer passes specifics via `with:`.
+- **Filename convention differs by scope:**
+  - *Shared* (cross-repo, in `gha-workflows`): non-underscore filename with a `_`-prefixed `name:` (e.g. file `app-build-dotnet.yml`, `name: _app-build-dotnet`), consumed via `uses: f2calv/gha-workflows/.github/workflows/<file>.yml@v1`.
+  - *Local* (same-repo): underscore-prefixed filename (e.g. `_gitops-helm-update.yml`), consumed via `uses: ./.github/workflows/_filename.yml`.
+
 ## Reusable Workflows
 
-- **File naming**: Prefix reusable workflow filenames with an underscore to distinguish them from top-level entry-point workflows (e.g. `_gitops-helm-update.yml`, `_deploy-maui-android.yml`).
+- **File naming**: Prefix local (same-repo) reusable workflow filenames with an underscore to distinguish them from top-level entry-point workflows (e.g. `_gitops-helm-update.yml`, `_deploy-maui-android.yml`).
 - **Same repo**: `uses: ./.github/workflows/_filename.yml`
 - **Cross-repo**: `uses: owner/repo/.github/workflows/filename.yml@v1`
 - Prefer `secrets: inherit` unless there is a specific reason to restrict secrets passed to the called workflow.

--- a/action.yml
+++ b/action.yml
@@ -74,7 +74,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       if: inputs.checkout == 'true'
       with:
         fetch-depth: 0


### PR DESCRIPTION
## Summary

Routine `2026-04` maintenance pass bringing this action repo in line with the shared f2calv conventions.

## Changes

- **Copilot instructions restructure** — split the monolithic `.github/copilot-instructions.md` into the shared "synced section" model with scoped instruction files under `.github/instructions/`:
  - `github-actions.instructions.md` — workflow / composite-action naming, YAML style, security and GitVersion conventions.
  - `documentation.instructions.md` — README consistency and Mermaid diagram conventions.
- **Composite action** — bumped `actions/checkout@v6` → `@v7` in `action.yml`.

## Notes

Documentation and convention updates plus a checkout bump only — no change to the action's runtime behaviour or public input/output contract.
