### PR TITLE
feat: run tests via Microsoft.Testing.Platform

### DIFF
--- a/.scripts/dotnet-test.sh
+++ b/.scripts/dotnet-test.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Runs 'dotnet test' in Microsoft.Testing.Platform (MTP) mode and gathers the cobertura coverage
+# reports produced by Microsoft.Testing.Extensions.CodeCoverage into $GITHUB_WORKSPACE/coverage.
+# Required environment variables: CONFIGURATION, GITHUB_WORKSPACE
+# Optional environment variables: SOLUTION_NAME, DOTNET_TEST_ARGS
+
+# Validate required environment variables before enabling strict mode
+for var in CONFIGURATION GITHUB_WORKSPACE; do
+  if [[ -z "${!var:-}" ]]; then
+    echo "::error::Required environment variable $var is not set."
+    exit 1
+  fi
+done
+
+set -euo pipefail
+
+: "${SOLUTION_NAME:=}"
+: "${DOTNET_TEST_ARGS:=}"
+
+#MTP mode rejects a positional path, the target must be named with --solution or --project.
+#An empty value is legitimate, dotnet test then discovers the solution/project in the working directory.
+target_args=()
+case "$SOLUTION_NAME" in
+  '') ;;
+  *.sln | *.slnx) target_args=(--solution "$SOLUTION_NAME") ;;
+  *.csproj) target_args=(--project "$SOLUTION_NAME") ;;
+  *)
+    echo "::error::solution-name '$SOLUTION_NAME' is not supported, expected a .sln, .slnx or .csproj file."
+    exit 1
+    ;;
+esac
+
+coverage_dir="$GITHUB_WORKSPACE/coverage"
+coverage_filename=coverage.cobertura.xml
+
+rm -rf "$coverage_dir"
+mkdir -p "$coverage_dir"
+
+#coverlet.msbuild (-p:CollectCoverage) and --collect are VSTest-era and are silently ignored under MTP.
+#A bare --coverage-output filename lands in each test project's own TestResults folder, which keeps the
+#reports distinct when a solution contains more than one test project. They are gathered up afterwards.
+cmd=(dotnet test)
+cmd+=("${target_args[@]}")
+cmd+=(-c "$CONFIGURATION" --no-restore --no-build --nologo)
+cmd+=(--coverage --coverage-output-format cobertura --coverage-output "$coverage_filename")
+
+#dotnet-test-args is a free-form string, word splitting it here is intentional.
+extra_args=()
+read -ra extra_args <<<"$DOTNET_TEST_ARGS"
+cmd+=("${extra_args[@]}")
+
+echo "${cmd[*]}"
+"${cmd[@]}"
+
+report_count=0
+while IFS= read -r -d '' report; do
+  #Flatten the workspace-relative path into the filename so reports from sibling projects cannot collide.
+  relative_path="${report#"$GITHUB_WORKSPACE"/}"
+  cp "$report" "$coverage_dir/${relative_path//\//-}"
+  report_count=$((report_count + 1))
+done < <(find "$GITHUB_WORKSPACE" -type f -name "$coverage_filename" -not -path "$coverage_dir/*" -print0)
+
+if [[ $report_count -eq 0 ]]; then
+  echo "::warning title=Code coverage::No $coverage_filename reports were produced, is Microsoft.Testing.Extensions.CodeCoverage referenced by the test project(s)?"
+else
+  echo "Gathered $report_count coverage report(s) into $coverage_dir"
+fi

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ These projects use this action directly due to a non-standard testing process:
 | `checkout` | boolean | | `true` | Checkout the current repository |
 | `checkout-ref` | string | | | Git ref to checkout e.g. `v1.2.3` or a commit SHA. Empty checks out the triggering ref. |
 | `configuration` | string | | `Release` | .NET build configuration e.g. `Debug` or `Release` |
-| `solution-name` | string | | | Specify exactly which .NET solution or project to build when multiple exist e.g. `MySolution.sln` or `MyProject.csproj` |
+| `solution-name` | string | | | .NET solution or project to build e.g. `MySolution.slnx` or `MyProject.csproj`. Empty targets the working directory. |
 | `push` | boolean | | `true` | Push packages to NuGet feeds |
 | `push-preview` | boolean | | `false` | Push a pre-release NuGet package from a non-default branch. The version's SemVer pre-release suffix signals preview status to NuGet. |
 | `execute-tests` | boolean | | `true` | Execute unit tests |
@@ -118,6 +118,35 @@ Credential per feed:
 When `package-filter` is set, only `.nupkg` files whose filename starts with one of the specified prefixes are pushed. This is useful during preview pushes to avoid cluttering nuget.org with packages that haven't actually changed.
 
 For example, if a solution produces `CasCap.Common.Caching`, `CasCap.Common.Extensions`, and `CasCap.Common.Serialization` packages, setting `package-filter: CasCap.Common.Caching` will push only the caching package.
+
+## Testing and code coverage
+
+`dotnet test` runs in [Microsoft.Testing.Platform](https://learn.microsoft.com/dotnet/core/testing/unit-testing-with-dotnet-test#mtp-mode-of-dotnet-test) (MTP) mode, which every consuming repository must opt into via `global.json`:
+
+```json
+{
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  }
+}
+```
+
+MTP mode is mandatory rather than optional — `xunit.v3` 4.0.0 dropped the VSTest bridge, and the .NET 10 SDK fails any VSTest-targeted `dotnet test` run against an MTP test project.
+
+Because MTP does not accept a positional path, `solution-name` is translated into `--solution` (for `.sln` / `.slnx`) or `--project` (for `.csproj`). Any other value fails the step with an explicit error.
+
+Coverage is collected by the [`Microsoft.Testing.Extensions.CodeCoverage`](https://learn.microsoft.com/dotnet/core/testing/unit-testing-platform-extensions-code-coverage) package, which each test project must reference. The VSTest-era `coverlet.msbuild` / `coverlet.collector` / `--collect` route no longer applies and the following packages can be removed from MTP-only test projects:
+
+- `Microsoft.NET.Test.Sdk` — set `<OutputType>Exe</OutputType>` in the test project when removing it
+- `xunit.runner.visualstudio`
+- `coverlet.collector`
+- `coverlet.msbuild`
+
+The coverage pipeline is:
+
+1. `dotnet test --coverage --coverage-output-format cobertura` writes a `coverage.cobertura.xml` per test project, which the action gathers into `coverage/`.
+2. `ReportGenerator` converts those cobertura reports into lcov under `coveragereport/`.
+3. Coveralls consumes the generated lcov, and `coveragereport/` is published as a build artifact.
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -34,9 +34,11 @@ inputs:
     type: string
     description: .NET Configuration e.g. Debug or Release
     default: Release
+  #Empty targets whatever solution/project lives in the working directory. Because 'dotnet test' runs in
+  #Microsoft.Testing.Platform mode the value must resolve to a .sln, .slnx or .csproj file, nothing else.
   solution-name:
     type: string
-    description: Specify exactly which .NET solution or project to build when multiple exist. e.g. MySolution.sln or MyProject.csproj
+    description: .NET solution or project to build e.g. MySolution.slnx or MyProject.csproj
     default: ''
   push:
     type: boolean
@@ -121,14 +123,28 @@ runs:
     - name: dotnet test
       if: inputs.execute-tests == 'true'
       shell: bash
-      run: dotnet test ${{ inputs.solution-name }} -c ${{ steps.setvars.outputs.configuration }} --no-restore --nologo --no-build -p:CollectCoverage=true -p:CoverletOutputFormat=lcov -p:CoverletOutput=${{ github.workspace }}/coverage/ ${{ inputs.dotnet-test-args }}
+      env:
+        CONFIGURATION: ${{ steps.setvars.outputs.configuration }}
+        SOLUTION_NAME: ${{ inputs.solution-name }}
+        DOTNET_TEST_ARGS: ${{ inputs.dotnet-test-args }}
+      run: "${{ github.action_path }}/.scripts/dotnet-test.sh"
+
+    #Microsoft.Testing.Platform emits cobertura, coveralls consumes lcov, so ReportGenerator converts first.
+    - name: code coverage - report generator
+      if: inputs.execute-tests == 'true' && inputs.code-coverage == 'true'
+      uses: danielpalme/ReportGenerator-GitHub-Action@v5
+      with:
+        reports: ${{ github.workspace }}/coverage/**/*.cobertura.xml
+        targetdir: ${{ github.workspace }}/coveragereport
+        reporttypes: lcov
+        tag: ${{ github.run_number }}_${{ github.run_id }}
 
     - name: code coverage - coveralls (1 of 2)
       shell: bash
-      if: inputs.execute-tests == 'true'
+      if: inputs.execute-tests == 'true' && inputs.code-coverage == 'true'
       id: coveralls
       run: |
-        files=$(find ${{ github.workspace }}/coverage -type f -printf '%p ')
+        files=$(find ${{ github.workspace }}/coveragereport -type f -name '*.info' -printf '%p ')
         echo "files=$files" >> $GITHUB_OUTPUT
 
     - name: code coverage - coveralls (2 of 2)
@@ -136,15 +152,6 @@ runs:
       uses: coverallsapp/github-action@v2
       with:
         files: ${{ steps.coveralls.outputs.files }}
-
-    - name: code coverage - report generator
-      if: inputs.execute-tests == 'true' && inputs.code-coverage == 'true'
-      uses: danielpalme/ReportGenerator-GitHub-Action@v5
-      with:
-        reports: ${{ github.workspace }}/coverage/**.info
-        targetdir: ${{ github.workspace }}/coveragereport
-        reporttypes: lcov
-        tag: ${{ github.run_number }}_${{ github.run_id }}
 
     - name: code coverage - upload-artifact
       if: inputs.execute-tests == 'true' && inputs.code-coverage == 'true'


### PR DESCRIPTION
xunit.v3 4.0 drops the VSTest bridge, and the .NET 10 SDK refuses the old path, so dotnet test must run in MTP mode. coverlet is VSTest-era and does not work under MTP, so coverage moves to Microsoft.Testing.Extensions.

- extract dotnet test into .scripts/dotnet-test.sh, translating solution-name to --solution or --project as MTP mode requires
- emit cobertura per project, gathered with path-derived names; a shared --coverage-output would have had projects overwrite each other
- run ReportGenerator first to convert cobertura to lcov, so Coveralls is unchanged