### PR TITLE
fix: support both VSTest and MTP dotnet test modes

### DIFF
--- a/.scripts/dotnet-test.sh
+++ b/.scripts/dotnet-test.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
-# Runs 'dotnet test' in Microsoft.Testing.Platform (MTP) mode and gathers the cobertura coverage
-# reports produced by Microsoft.Testing.Extensions.CodeCoverage into $GITHUB_WORKSPACE/coverage.
+# Runs 'dotnet test' in whichever test runner mode the consuming repository has opted into and leaves
+# coverage reports in $GITHUB_WORKSPACE/coverage for the ReportGenerator step to pick up.
+# Microsoft.Testing.Platform (MTP) mode is selected by a global.json 'test.runner' opt-in and emits
+# cobertura; every other repository keeps the legacy VSTest command line and emits coverlet lcov.
 # Required environment variables: CONFIGURATION, GITHUB_WORKSPACE
 # Optional environment variables: SOLUTION_NAME, DOTNET_TEST_ARGS
 
@@ -17,18 +19,22 @@ set -euo pipefail
 : "${SOLUTION_NAME:=}"
 : "${DOTNET_TEST_ARGS:=}"
 
-#MTP mode rejects a positional path, the target must be named with --solution or --project.
-#An empty value is legitimate, dotnet test then discovers the solution/project in the working directory.
-target_args=()
-case "$SOLUTION_NAME" in
-  '') ;;
-  *.sln | *.slnx) target_args=(--solution "$SOLUTION_NAME") ;;
-  *.csproj) target_args=(--project "$SOLUTION_NAME") ;;
-  *)
-    echo "::error::solution-name '$SOLUTION_NAME' is not supported, expected a .sln, .slnx or .csproj file."
-    exit 1
-    ;;
-esac
+mtp_runner=Microsoft.Testing.Platform
+global_json="$GITHUB_WORKSPACE/global.json"
+
+#Runner detection is advisory, never fatal - a missing file, missing key, malformed JSON or a missing jq
+#all mean "not opted in", which selects the backward compatible VSTest command line.
+test_runner=''
+if [[ ! -f "$global_json" ]]; then
+  detection_reason="no global.json found at $global_json"
+elif ! command -v jq >/dev/null 2>&1; then
+  detection_reason="jq is unavailable so global.json could not be parsed"
+elif ! test_runner=$(jq -er '.test.runner' "$global_json" 2>/dev/null); then
+  test_runner=''
+  detection_reason="global.json declares no .test.runner value (or is not valid JSON)"
+else
+  detection_reason="global.json declares .test.runner = $test_runner"
+fi
 
 coverage_dir="$GITHUB_WORKSPACE/coverage"
 coverage_filename=coverage.cobertura.xml
@@ -36,15 +42,43 @@ coverage_filename=coverage.cobertura.xml
 rm -rf "$coverage_dir"
 mkdir -p "$coverage_dir"
 
-#coverlet.msbuild (-p:CollectCoverage) and --collect are VSTest-era and are silently ignored under MTP.
-#A bare --coverage-output filename lands in each test project's own TestResults folder, which keeps the
-#reports distinct when a solution contains more than one test project. They are gathered up afterwards.
 cmd=(dotnet test)
-cmd+=("${target_args[@]}")
-#Note: --nologo is deliberately absent. In MTP mode it makes discovery report "Zero tests ran"
-#and exit 5, even though the same command without it runs the tests. Verified by bisection.
-cmd+=(-c "$CONFIGURATION" --no-restore --no-build)
-cmd+=(--coverage --coverage-output-format cobertura --coverage-output "$coverage_filename")
+
+if [[ "$test_runner" == "$mtp_runner" ]]; then
+  echo "Test runner mode: $mtp_runner ($detection_reason)"
+
+  #MTP mode rejects a positional path, the target must be named with --solution or --project.
+  #An empty value is legitimate, dotnet test then discovers the solution/project in the working directory.
+  case "$SOLUTION_NAME" in
+    '') ;;
+    *.sln | *.slnx) cmd+=(--solution "$SOLUTION_NAME") ;;
+    *.csproj) cmd+=(--project "$SOLUTION_NAME") ;;
+    *)
+      echo "::error::solution-name '$SOLUTION_NAME' is not supported, expected a .sln, .slnx or .csproj file."
+      exit 1
+      ;;
+  esac
+
+  #coverlet.msbuild (-p:CollectCoverage) and --collect are VSTest-era and are silently ignored under MTP.
+  #A bare --coverage-output filename lands in each test project's own TestResults folder, which keeps the
+  #reports distinct when a solution contains more than one test project. They are gathered up afterwards.
+  #Note: --nologo is deliberately absent. In MTP mode it makes discovery report "Zero tests ran"
+  #and exit 5, even though the same command without it runs the tests. Verified by bisection.
+  cmd+=(-c "$CONFIGURATION" --no-restore --no-build)
+  cmd+=(--coverage --coverage-output-format cobertura --coverage-output "$coverage_filename")
+else
+  echo "Test runner mode: VSTest ($detection_reason), opt into $mtp_runner by adding a test.runner entry to global.json."
+
+  #VSTest mode takes the target as a bare positional path, an empty value discovers it in the working directory.
+  if [[ -n "$SOLUTION_NAME" ]]; then
+    cmd+=("$SOLUTION_NAME")
+  fi
+
+  #--nologo only breaks discovery under MTP, it is correct here. coverlet.msbuild writes lcov straight
+  #into $coverage_dir so there is nothing to gather afterwards.
+  cmd+=(-c "$CONFIGURATION" --no-restore --nologo --no-build)
+  cmd+=(-p:CollectCoverage=true -p:CoverletOutputFormat=lcov -p:CoverletOutput="$coverage_dir/")
+fi
 
 #dotnet-test-args is a free-form string, word splitting it here is intentional.
 extra_args=()
@@ -53,6 +87,11 @@ cmd+=("${extra_args[@]}")
 
 echo "${cmd[*]}"
 "${cmd[@]}"
+
+#Only MTP scatters its reports across the test projects, coverlet already wrote lcov into $coverage_dir.
+if [[ "$test_runner" != "$mtp_runner" ]]; then
+  exit 0
+fi
 
 report_count=0
 while IFS= read -r -d '' report; do

--- a/README.md
+++ b/README.md
@@ -121,7 +121,14 @@ For example, if a solution produces `CasCap.Common.Caching`, `CasCap.Common.Exte
 
 ## Testing and code coverage
 
-`dotnet test` runs in [Microsoft.Testing.Platform](https://learn.microsoft.com/dotnet/core/testing/unit-testing-with-dotnet-test#mtp-mode-of-dotnet-test) (MTP) mode, which every consuming repository must opt into via `global.json`:
+Both `dotnet test` runner modes are supported. The mode is detected from the consuming repository's `global.json`, so no action input needs to change:
+
+| `global.json` | Mode | Coverage |
+| --- | --- | --- |
+| `test.runner` is `Microsoft.Testing.Platform` | [Microsoft.Testing.Platform](https://learn.microsoft.com/dotnet/core/testing/unit-testing-with-dotnet-test#mtp-mode-of-dotnet-test) (MTP) | cobertura |
+| anything else, or no `global.json` | VSTest (default) | coverlet lcov |
+
+VSTest is the default purely for backward compatibility — a repository that has not opted in keeps working unchanged. Opt into MTP by adding:
 
 ```json
 {
@@ -131,9 +138,11 @@ For example, if a solution produces `CasCap.Common.Caching`, `CasCap.Common.Exte
 }
 ```
 
-MTP mode is mandatory rather than optional — `xunit.v3` 4.0.0 dropped the VSTest bridge, and the .NET 10 SDK fails any VSTest-targeted `dotnet test` run against an MTP test project.
+Opting in is necessary once a test project goes MTP-only — `xunit.v3` 4.0.0 dropped the VSTest bridge, and the .NET 10 SDK fails any VSTest-targeted `dotnet test` run against an MTP test project.
 
-Because MTP does not accept a positional path, `solution-name` is translated into `--solution` (for `.sln` / `.slnx`) or `--project` (for `.csproj`). Any other value fails the step with an explicit error.
+### MTP mode
+
+MTP does not accept a positional path, so `solution-name` is translated into `--solution` (for `.sln` / `.slnx`) or `--project` (for `.csproj`). Any other value fails the step with an explicit error.
 
 Coverage is collected by the [`Microsoft.Testing.Extensions.CodeCoverage`](https://learn.microsoft.com/dotnet/core/testing/unit-testing-platform-extensions-code-coverage) package, which each test project must reference. The VSTest-era `coverlet.msbuild` / `coverlet.collector` / `--collect` route no longer applies and the following packages can be removed from MTP-only test projects:
 
@@ -142,10 +151,14 @@ Coverage is collected by the [`Microsoft.Testing.Extensions.CodeCoverage`](https
 - `coverlet.collector`
 - `coverlet.msbuild`
 
-The coverage pipeline is:
+### VSTest mode
 
-1. `dotnet test --coverage --coverage-output-format cobertura` writes a `coverage.cobertura.xml` per test project, which the action gathers into `coverage/`.
-2. `ReportGenerator` converts those cobertura reports into lcov under `coveragereport/`.
+`solution-name` is passed through as a bare positional path. Coverage is collected by `coverlet.msbuild` (`-p:CollectCoverage=true -p:CoverletOutputFormat=lcov`), which each test project must reference.
+
+### Coverage pipeline
+
+1. `dotnet test` writes a cobertura report per test project (MTP, gathered into `coverage/`) or lcov directly into `coverage/` (VSTest).
+2. `ReportGenerator` reads both formats from `coverage/` and normalises them to lcov under `coveragereport/`.
 3. Coveralls consumes the generated lcov, and `coveragereport/` is published as a build artifact.
 
 ## Outputs

--- a/action.yml
+++ b/action.yml
@@ -34,8 +34,8 @@ inputs:
     type: string
     description: .NET Configuration e.g. Debug or Release
     default: Release
-  #Empty targets whatever solution/project lives in the working directory. Because 'dotnet test' runs in
-  #Microsoft.Testing.Platform mode the value must resolve to a .sln, .slnx or .csproj file, nothing else.
+  #Empty targets whatever solution/project lives in the working directory. Under Microsoft.Testing.Platform
+  #mode 'dotnet test' rejects a positional path, so the value must then resolve to a .sln, .slnx or .csproj.
   solution-name:
     type: string
     description: .NET solution or project to build e.g. MySolution.slnx or MyProject.csproj
@@ -129,12 +129,15 @@ runs:
         DOTNET_TEST_ARGS: ${{ inputs.dotnet-test-args }}
       run: "${{ github.action_path }}/.scripts/dotnet-test.sh"
 
-    #Microsoft.Testing.Platform emits cobertura, coveralls consumes lcov, so ReportGenerator converts first.
+    #Microsoft.Testing.Platform emits cobertura and coverlet (VSTest mode) emits lcov, coveralls consumes
+    #lcov, so ReportGenerator is pointed at both formats and normalises whichever one is present.
     - name: code coverage - report generator
       if: inputs.execute-tests == 'true' && inputs.code-coverage == 'true'
       uses: danielpalme/ReportGenerator-GitHub-Action@v5
       with:
-        reports: ${{ github.workspace }}/coverage/**/*.cobertura.xml
+        #cobertura comes from MTP mode, lcov from coverlet in VSTest mode. The bare '**.info'
+        #spelling is the one this action shipped for years, so it is kept alongside '**/*.info'.
+        reports: ${{ github.workspace }}/coverage/**/*.cobertura.xml;${{ github.workspace }}/coverage/**.info;${{ github.workspace }}/coverage/**/*.info
         targetdir: ${{ github.workspace }}/coveragereport
         reporttypes: lcov
         tag: ${{ github.run_number }}_${{ github.run_id }}


### PR DESCRIPTION
The MTP-only test command shipped on the floating v2 tag broke every consumer that had not opted in, since dotnet test rejects --solution and --coverage in VSTest mode (MSBUILD error MSB1001).

- detect the global.json Microsoft.Testing.Platform opt-in and emit the matching command; anything else falls back to the previous VSTest invocation with coverlet, so v2 is non-breaking again
- treat a missing file, missing key, absent jq or malformed JSON as not-opted-in rather than failing the build
- accept cobertura and lcov in ReportGenerator, keeping the long-standing '**.info' glob alongside the newer spelling